### PR TITLE
(feat): permitir configurar o memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,6 @@ COPY configs/ports.conf /etc/apache2/ports.conf
 COPY configs/logs.conf /etc/apache2/conf-enabled/logs.conf
 COPY configs/php-errors.ini /usr/local/etc/php/conf.d/php-errors.ini
 COPY configs/php-memory-limit.ini /usr/local/etc/php/conf.d/php-memory-limit.ini
-COPY configs/php-memory-limit-apache.ini.dist /usr/local/etc/php/conf.d/php-memory-limit-apache.ini.dist
 COPY ./bin /usr/local/bin/
 
 RUN chmod a+x \

--- a/bin/apache-run
+++ b/bin/apache-run
@@ -12,7 +12,7 @@ sudo -E newrelic-setup
 sudo -E opcache-setup
 
 if [[ ${PHP_USE_MEMORY_LIMIT_APACHE} == true ]]; then
-    sudo cp /usr/local/etc/php/conf.d/php-memory-limit-apache.ini.dist /usr/local/etc/php/conf.d/php-memory-limit.ini
+    export PHP_MEMORY_LIMIT=128M
 fi
 
 if [[ ${SESSION_HANDLER} == true ]]; then

--- a/configs/php-memory-limit-apache.ini.dist
+++ b/configs/php-memory-limit-apache.ini.dist
@@ -1,1 +1,0 @@
-memory_limit = 128M


### PR DESCRIPTION
A ideia é que os containers executados sem o apache (cli) não tenham limitação de memória.